### PR TITLE
Fix issue when bootstrap is not fully imported

### DIFF
--- a/src/js/components/Modal.js
+++ b/src/js/components/Modal.js
@@ -1,4 +1,5 @@
 import Bs5Utils from "../Bs5Utils";
+import {Modal as ModalBs} from "bootstrap";
 
 export default class Modal {
     /**
@@ -107,7 +108,7 @@ export default class Modal {
             focus
         };
 
-        const bsModal = new bootstrap.Modal(modal, opts);
+        const bsModal = new ModalBs(modal, opts);
 
         bsModal.show();
 

--- a/src/js/components/Snack.js
+++ b/src/js/components/Snack.js
@@ -1,4 +1,5 @@
 import Bs5Utils from "../Bs5Utils";
+import {Toast} from "bootstrap";
 
 export default class Snack {
     /**
@@ -54,7 +55,7 @@ export default class Snack {
             opts['delay'] = delay;
         }
 
-        const bsSnack = new bootstrap.Toast(snack, opts);
+        const bsSnack = new Toast(snack, opts);
 
         bsSnack.show();
 

--- a/src/js/components/Toast.js
+++ b/src/js/components/Toast.js
@@ -1,4 +1,5 @@
 import Bs5Utils from "../Bs5Utils";
+import {Toast as ToastBs} from "bootstrap"
 
 export default class Toast {
     /**
@@ -111,7 +112,7 @@ export default class Toast {
             opts['delay'] = delay;
         }
 
-        const bsToast = new bootstrap.Toast(toast, opts);
+        const bsToast = new ToastBs(toast, opts);
 
         bsToast.show();
 


### PR DESCRIPTION
Hello,

When each bootstrap module is imported individually, for exemple, `import {Alert, Collapse, Dropdown} from 'bootstrap'` in your application, an error occured using Bs5Utils : `Uncaught ReferenceError: bootstrap is not defined`

In the case of Modal, instead of using `const bsModal = new bootstrap.Modal(modal, opts);` we now use bootsrap module :
```js
import {Modal as ModalBs} from "bootstrap";

const bsModal = new ModalBs(modal, opts);
```

With this fix, the error doesn't occur anymore for Modal, Toast and Snack.